### PR TITLE
feat(admin): provision authorized profiles on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 ## Obs
 
 Para funcionar a busca de revisores, e necessario adicionar indices para os campos `profiles.user.email` e `profiles.user.name` no Firestore.
+
+O provisionamento de contas do painel e a integração de perfis com a Pokedex
+estão documentados em
+[docs/admin-authentication.md](docs/admin-authentication.md).

--- a/docs/admin-authentication.md
+++ b/docs/admin-authentication.md
@@ -1,0 +1,73 @@
+# Autenticação e autorização administrativa
+
+O painel usa Firebase Authentication com e-mail e senha para comprovar a
+identidade. A existência da conta no Authentication não concede acesso ao
+painel: a autorização é mantida separadamente na coleção `adminUsers`.
+
+## Provisionamento
+
+Para autorizar uma pessoa administradora:
+
+1. crie ou localize a conta Email/Password no Firebase Authentication;
+2. copie o Firebase UID da conta;
+3. crie `adminUsers/{uid}` no Firestore;
+4. adicione o campo booleano `isActive: true`.
+
+```json
+{
+  "isActive": true
+}
+```
+
+Definir `isActive: false` ou remover o documento impede novas autorizações no
+painel. O documento e a coleção não são acessíveis pelo Client SDK; somente o
+backend, usando Firebase Admin, consulta essa autorização.
+
+## Primeiro login
+
+Depois de validar o token e confirmar que o provedor da sessão é `password`, o
+backend executa uma transação que lê `adminUsers/{uid}` e procura o perfil:
+
+1. pelo Firebase UID;
+2. pelo e-mail autenticado normalizado;
+3. cria `profiles/{uid}` somente quando nenhuma busca encontra um perfil.
+
+Um perfil encontrado é promovido substituindo `accessRoles` por `['admin']`.
+Administradores não recebem o papel `participant`. Um perfil criado pelo painel
+já nasce com `onboardingCompleted: true` e com todos os campos exigidos pelo
+contrato compartilhado com a Pokedex.
+
+Se houver mais de um perfil para o mesmo e-mail, ou conflito entre um perfil
+encontrado pelo UID e outro encontrado pelo e-mail, a autorização falha sem
+alterar documentos. A duplicidade deve ser resolvida manualmente antes de uma
+nova tentativa.
+
+## Integração com a Pokedex
+
+Os projetos usam identificadores diferentes: o painel recebe o Firebase UID,
+enquanto a Pokedex usa o `sub` estável da conta Google. Por isso, ambos tentam o
+identificador primário e usam o e-mail normalizado como fallback controlado.
+
+Se a Pokedex criou o perfil primeiro, o painel promove esse mesmo documento. Se
+o painel criou primeiro, a Pokedex reutiliza o perfil administrativo pelo
+e-mail e não cria um participante duplicado. Essa associação exige que as
+contas Email/Password e Google usem o mesmo endereço de e-mail.
+
+## Ambientes
+
+O site usa `DEV_MODE=true` para prefixar coleções com `test_`; nesse ambiente,
+cadastre a autorização em `test_adminUsers/{uid}` e confira o resultado em
+`test_profiles`. Em produção, use `adminUsers/{uid}` e `profiles`.
+
+A Pokedex usa a variável `DEVMODE=true` (sem underscore) para acessar as mesmas
+coleções prefixadas durante testes integrados.
+
+## Checklist de teste
+
+- confirme que a conta Email/Password possui o e-mail esperado;
+- crie `adminUsers/{uid}` ou `test_adminUsers/{uid}` com `isActive: true`;
+- entre no painel e confirme `accessRoles: ['admin']` no perfil;
+- entre na Pokedex com o mesmo e-mail Google;
+- confirme que nenhum segundo perfil foi criado;
+- defina `isActive: false`, encerre a sessão e confirme que o painel retorna
+  acesso não autorizado.

--- a/docs/admin-roadmap.md
+++ b/docs/admin-roadmap.md
@@ -32,28 +32,33 @@ gravar documentos compatíveis com os contratos consumidos pela Pokedex.
 
 ### 1. Autorização administrativa
 
-Separar autenticação de autorização e exigir o papel no perfil do usuário:
+Separar autenticação de autorização. Firebase Authentication comprova a
+identidade, `adminUsers/{uid}` autoriza o acesso administrativo e o perfil
+materializa o papel efetivo:
 
 ```ts
 {
-  accessRoles: ["participant", "admin"];
+  accessRoles: ["admin"];
 }
 ```
 
 Entregas:
 
-- [x] Criar `requireAdmin()` para validar token e `profiles/{uid}.accessRoles`.
+- [x] Criar `requireAdmin()` para validar token e `adminUsers/{uid}`.
+- [x] Criar ou promover o perfil administrativo no primeiro login autorizado.
+- [x] Resolver perfis compartilhados por UID e e-mail sem criar duplicatas.
 - [x] Substituir `requireAuth()` nas APIs administrativas.
 - [x] Retornar `401` para sessão inválida e `403` para usuário sem papel.
 - [x] Criar experiência de acesso não autorizado.
 - [x] Atualizar a autorização quando `accessRoles` for alterado.
 - [ ] Registrar operador e horário nas mutações administrativas.
 
-Critério de aceite: um usuário cujo perfil não contenha `admin` em `accessRoles`
-não acessa páginas nem APIs administrativas.
+Critério de aceite: somente uma conta Email/Password com
+`adminUsers/{uid}.isActive == true` acessa páginas e APIs administrativas.
 
-O papel é administrado no documento de perfil. O site não cria perfis nem altera
-`accessRoles` como efeito colateral do login.
+O primeiro login autorizado cria um perfil compatível com a Pokedex ou promove
+o perfil encontrado, substituindo `accessRoles` por `["admin"]`. O fluxo está
+detalhado em [Autenticação e autorização administrativa](./admin-authentication.md).
 
 ### 2. Regras do Firestore
 

--- a/docs/firestore-indexes.md
+++ b/docs/firestore-indexes.md
@@ -11,6 +11,10 @@ A proteção relacional de palestras consulta `schedule.activity.talkId` e a de
 palestrantes consulta `talks.speakerIds` com `array-contains`; ambas usam
 índices automáticos de campo único.
 
+A autorização administrativa busca `profiles.email` para reconciliar o
+Firebase UID do painel com o Google `sub` usado pela Pokedex. Essa consulta usa
+o índice automático de campo único. Não desative o índice de `profiles.email`.
+
 Não desative índices para `eventId`, `activity.talkId` ou `speakerIds`.
 Os nomes reais das coleções podem receber o sufixo de ambiente definido por
 `getFirestoreCollectionName()`.

--- a/src/back-features/admin-authorization.ts
+++ b/src/back-features/admin-authorization.ts
@@ -1,48 +1,95 @@
 import { z } from "zod";
 import type admin from "firebase-admin";
+import { Timestamp } from "firebase-admin/firestore";
 
+import {
+  buildInitialAdminProfile,
+  getAdminProfileIdentity,
+  resolveAdminProfileDocumentId,
+} from "@/back-features/admin-profile";
 import { db } from "@/utils/db";
 import { getFirestoreCollectionName } from "@/utils/db/collection-name";
 
 const PROFILES_COLLECTION = getFirestoreCollectionName("profiles");
+const ADMIN_USERS_COLLECTION = getFirestoreCollectionName("adminUsers");
 const accessRolesSchema = z.array(
   z.enum(["participant", "staff", "reviewer", "editor", "admin"]),
 );
-const profileAuthorizationSchema = z.object({
-  accessRoles: accessRolesSchema.default(["participant"]),
+type AccessRole = z.infer<typeof accessRolesSchema>[number];
+const adminUserAuthorizationSchema = z.object({
+  isActive: z.literal(true),
 });
 
-function parseAccessRoles(profileData: unknown) {
-  const result = profileAuthorizationSchema.safeParse(profileData);
-  return result.success ? result.data.accessRoles : [];
-}
-
-export async function getProfileAccessRoles(user: admin.auth.DecodedIdToken) {
-  const profiles = db.collection(PROFILES_COLLECTION);
-  const profileByUid = await profiles.doc(user.uid).get();
-
-  if (profileByUid.exists) {
-    return parseAccessRoles(profileByUid.data());
-  }
-
+export async function getProfileAccessRoles(
+  user: admin.auth.DecodedIdToken,
+): Promise<AccessRole[]> {
   const isPasswordSignIn = user.firebase?.sign_in_provider === "password";
-  if (!user.email || (!isPasswordSignIn && user.email_verified !== true)) {
+  if (!isPasswordSignIn || !user.email) {
     return [];
   }
 
-  const email = user.email.trim();
-  const normalizedEmail = email.toLowerCase();
-  const profileByEmail =
-    email === normalizedEmail
-      ? await profiles.where("email", "==", normalizedEmail).limit(2).get()
-      : await profiles
-          .where("email", "in", [email, normalizedEmail])
-          .limit(2)
-          .get();
+  const identity = getAdminProfileIdentity(user);
+  if (!identity) return [];
 
-  if (profileByEmail.size !== 1) return [];
+  const adminUserRef = db.collection(ADMIN_USERS_COLLECTION).doc(user.uid);
+  const profiles = db.collection(PROFILES_COLLECTION);
+  const directProfileRef = profiles.doc(user.uid);
+  const profilesByEmailQuery = profiles
+    .where("email", "==", identity.email)
+    .limit(2);
 
-  return parseAccessRoles(profileByEmail.docs[0].data());
+  return db.runTransaction<AccessRole[]>(async (transaction) => {
+    const [adminUser, directProfile, profilesByEmail] = await Promise.all([
+      transaction.get(adminUserRef),
+      transaction.get(directProfileRef),
+      transaction.get(profilesByEmailQuery),
+    ]);
+
+    const authorization = adminUserAuthorizationSchema.safeParse(
+      adminUser.data(),
+    );
+    if (!adminUser.exists || !authorization.success) return [];
+
+    const profileId = resolveAdminProfileDocumentId({
+      uid: user.uid,
+      directProfileExists: directProfile.exists,
+      emailProfileIds: profilesByEmail.docs.map((document) => document.id),
+    });
+    if (!profileId) return [];
+
+    const profile =
+      profileId === user.uid
+        ? directProfile
+        : profilesByEmail.docs.find((document) => document.id === profileId);
+    if (!profile) return [];
+
+    const currentRoles = accessRolesSchema.safeParse(
+      profile.data()?.accessRoles,
+    );
+    if (
+      profile.exists &&
+      currentRoles.success &&
+      currentRoles.data.length === 1 &&
+      currentRoles.data[0] === "admin"
+    ) {
+      return ["admin"];
+    }
+
+    const now = Timestamp.now();
+    const profileRef = profiles.doc(profileId);
+    if (profile.exists) {
+      transaction.update(profileRef, {
+        accessRoles: ["admin"],
+        updatedAt: now,
+      });
+    } else {
+      const initialProfile = buildInitialAdminProfile(user, now);
+      if (!initialProfile) return [];
+      transaction.create(profileRef, initialProfile);
+    }
+
+    return ["admin"];
+  });
 }
 
 export async function hasAdminRole(user: admin.auth.DecodedIdToken) {

--- a/src/back-features/admin-profile.test.ts
+++ b/src/back-features/admin-profile.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { DecodedIdToken } from "firebase-admin/auth";
+import { Timestamp } from "firebase-admin/firestore";
+
+import {
+  buildInitialAdminProfile,
+  getAdminProfileIdentity,
+  resolveAdminProfileDocumentId,
+} from "./admin-profile";
+
+const user = {
+  uid: "admin-user",
+  email: "Admin@Example.com",
+  name: "Admin User",
+  firebase: { sign_in_provider: "password" },
+} as unknown as DecodedIdToken;
+
+describe("admin profile", () => {
+  it("normaliza a identidade autenticada", () => {
+    assert.deepEqual(getAdminProfileIdentity(user), {
+      displayName: "Admin User",
+      email: "admin@example.com",
+      avatarUrl: null,
+    });
+  });
+
+  it("usa a parte local do email quando o usuário não possui nome", () => {
+    assert.equal(
+      getAdminProfileIdentity({ ...user, name: undefined })?.displayName,
+      "admin",
+    );
+  });
+
+  it("não cria identidade sem email", () => {
+    assert.equal(getAdminProfileIdentity({ ...user, email: undefined }), null);
+  });
+
+  it("cria um perfil exclusivamente administrativo e já finalizado", () => {
+    const now = Timestamp.fromMillis(1_700_000_000_000);
+    const profile = buildInitialAdminProfile(user, now);
+
+    assert.ok(profile);
+    assert.deepEqual(profile.accessRoles, ["admin"]);
+    assert.equal(profile.onboardingCompleted, true);
+    assert.equal(profile.userId, user.uid);
+    assert.equal(profile.createdAt, now);
+    assert.equal(profile.updatedAt, now);
+    assert.match(profile.qrId, /^[0-9a-f-]{36}$/);
+  });
+
+  it("reutiliza o perfil criado pela Pokedex quando o UID é diferente", () => {
+    assert.equal(
+      resolveAdminProfileDocumentId({
+        uid: "firebase-uid",
+        directProfileExists: false,
+        emailProfileIds: ["google-sub"],
+      }),
+      "google-sub",
+    );
+  });
+
+  it("usa o Firebase UID quando ainda não existe perfil", () => {
+    assert.equal(
+      resolveAdminProfileDocumentId({
+        uid: "firebase-uid",
+        directProfileExists: false,
+        emailProfileIds: [],
+      }),
+      "firebase-uid",
+    );
+  });
+
+  it("rejeita perfis duplicados para o mesmo email", () => {
+    assert.equal(
+      resolveAdminProfileDocumentId({
+        uid: "firebase-uid",
+        directProfileExists: false,
+        emailProfileIds: ["first-profile", "second-profile"],
+      }),
+      null,
+    );
+  });
+
+  it("rejeita conflito entre o perfil por UID e outro perfil por email", () => {
+    assert.equal(
+      resolveAdminProfileDocumentId({
+        uid: "firebase-uid",
+        directProfileExists: true,
+        emailProfileIds: ["google-sub"],
+      }),
+      null,
+    );
+  });
+});

--- a/src/back-features/admin-profile.ts
+++ b/src/back-features/admin-profile.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+
+import type admin from "firebase-admin";
+import { Timestamp } from "firebase-admin/firestore";
+
+import { CURRENT_EVENT_ID } from "@/helpers/event";
+
+export function getAdminProfileIdentity(
+  user: admin.auth.DecodedIdToken,
+): { displayName: string; email: string; avatarUrl: string | null } | null {
+  const email = user.email?.trim().toLowerCase();
+  if (!email) return null;
+
+  return {
+    displayName: user.name?.trim() || email.split("@")[0] || email,
+    email,
+    avatarUrl: user.picture?.trim() || null,
+  };
+}
+
+export function resolveAdminProfileDocumentId({
+  uid,
+  directProfileExists,
+  emailProfileIds,
+}: {
+  uid: string;
+  directProfileExists: boolean;
+  emailProfileIds: string[];
+}) {
+  const uniqueEmailProfileIds = [...new Set(emailProfileIds)];
+  if (uniqueEmailProfileIds.length > 1) return null;
+
+  const emailProfileId = uniqueEmailProfileIds[0];
+  if (directProfileExists) {
+    return emailProfileId && emailProfileId !== uid ? null : uid;
+  }
+
+  return emailProfileId ?? uid;
+}
+
+export function buildInitialAdminProfile(
+  user: admin.auth.DecodedIdToken,
+  now = Timestamp.now(),
+) {
+  const identity = getAdminProfileIdentity(user);
+  if (!identity) return null;
+
+  return {
+    userId: user.uid,
+    eventId: CURRENT_EVENT_ID,
+    ...identity,
+    gender: null,
+    bio: null,
+    role: null,
+    company: null,
+    linkedinUsername: null,
+    website: null,
+    skills: [],
+    accessRoles: ["admin"],
+    ticketBalance: 0,
+    convertedXp: 0,
+    qrId: randomUUID(),
+    onboardingCompleted: true,
+    onboardingTicketGranted: false,
+    xp: 0,
+    xpReachedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  };
+}


### PR DESCRIPTION
## Descrição

Desacopla a autorização administrativa da criação prévia de perfis pela Pokedex.

O Firebase Authentication continua responsável pela identidade, enquanto a coleção `adminUsers/{uid}` define quais contas Email/Password podem acessar o painel.

## Alterações

- valida `adminUsers/{firebaseUid}` com `isActive: true`;
- cria um perfil administrativo no primeiro login autorizado;
- promove perfis existentes para `accessRoles: ["admin"]`;
- procura perfis por Firebase UID e e-mail normalizado;
- reutiliza perfis criados anteriormente pela Pokedex;
- rejeita conflitos ou múltiplos perfis com o mesmo e-mail;
- impede a criação de perfis para usuários não autorizados;
- adiciona testes para criação, promoção e resolução de identidade;
- documenta provisionamento, ambientes e roteiro de testes.

## Provisionamento

Para cadastrar um administrador:

1. Criar a conta Email/Password no Firebase Authentication.
2. Copiar o Firebase UID.
3. Criar `adminUsers/{uid}` no Firestore.
4. Adicionar o campo booleano `isActive: true`.

Em desenvolvimento, com `DEV_MODE=true`, utilizar `test_adminUsers/{uid}`.

## Validação

- 40 testes aprovados;
- TypeScript sem erros;
- ESLint sem avisos;
- Prettier e `git diff --check` aprovados.